### PR TITLE
feat :RejectedException 예외처리 Handler 적용

### DIFF
--- a/server/src/main/java/kr/flab/ottsharing/supports/AsyncConfiguration.java
+++ b/server/src/main/java/kr/flab/ottsharing/supports/AsyncConfiguration.java
@@ -30,7 +30,7 @@ public class AsyncConfiguration implements AsyncConfigurer {
 
     private static final Logger log = LoggerFactory.getLogger(AsyncConfiguration.class);
 
-    private static int TASK_QUEUE_CAPACITY = 50;
+    private static int TASK_QUEUE_CAPACITY = 100;
     private static int KEEP_ALIVE_SECOND = 60;
     private static String THREAD_NAME_PREFIX = "asyncTask-";
 
@@ -46,6 +46,7 @@ public class AsyncConfiguration implements AsyncConfigurer {
         taskExecutor.setQueueCapacity(TASK_QUEUE_CAPACITY);
         taskExecutor.setKeepAliveSeconds(KEEP_ALIVE_SECOND);
         taskExecutor.setThreadNamePrefix(THREAD_NAME_PREFIX);
+        taskExecutor.setRejectedExecutionHandler(new CustomRejectedExceptionHandler());
 
         taskExecutor.initialize();
         return taskExecutor;

--- a/server/src/main/java/kr/flab/ottsharing/supports/CustomRejectedExceptionHandler.java
+++ b/server/src/main/java/kr/flab/ottsharing/supports/CustomRejectedExceptionHandler.java
@@ -8,12 +8,12 @@ import java.util.concurrent.ThreadPoolExecutor;
 
 public class CustomRejectedExceptionHandler implements RejectedExecutionHandler {
 
-    private static Logger logger = LoggerFactory.getLogger(CustomRejectedExceptionHandler.class);
+    private static final Logger logger = LoggerFactory.getLogger(CustomRejectedExceptionHandler.class);
 
     @Override
     public void rejectedExecution(Runnable r, ThreadPoolExecutor executor) {
         logger.error("==============>>>>>>>>>>>> RejectedExecution ERROR");
-        logger.error("CompletedTaskCount() :: {}", executor);
+        logger.error("RejectedException 발생 :: {}", executor);
         logger.error("==============>>>>>>>>>>>> RejectedExecution ERROR END");
     }
 }

--- a/server/src/main/java/kr/flab/ottsharing/supports/CustomRejectedExceptionHandler.java
+++ b/server/src/main/java/kr/flab/ottsharing/supports/CustomRejectedExceptionHandler.java
@@ -1,0 +1,19 @@
+package kr.flab.ottsharing.supports;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.ThreadPoolExecutor;
+
+public class CustomRejectedExceptionHandler implements RejectedExecutionHandler {
+
+    private static Logger logger = LoggerFactory.getLogger(CustomRejectedExceptionHandler.class);
+
+    @Override
+    public void rejectedExecution(Runnable r, ThreadPoolExecutor executor) {
+        logger.error("==============>>>>>>>>>>>> RejectedExecution ERROR");
+        logger.error("CompletedTaskCount() :: {}", executor);
+        logger.error("==============>>>>>>>>>>>> RejectedExecution ERROR END");
+    }
+}


### PR DESCRIPTION
*  동시간대 다수의 요청 처리시  TransactionalEventListener로 이벤트를 처리하는 곳에서 이벤트 누락 예외인 TaskRejectedException를 잡지 못하는 것을 확인함
* 따라서, runtime에 TaskRejectedException을 잡도록 RejectedExecutionHandler의 구현체인 CustomRejectedExceptionHandler를 적용함. 
-- 해당 handler는 누락된 이벤트가 발생시 log를 통해 예외가 발생하였다고 표시하도록 함. 
-- 누락된 이벤트에 대한 정확한 정보를 얻기위해서는 mdc를 적용하거나 카프카로 전환하는 방법이 필요로함. 
-- 현상황에서는 위의 두 방법을 적용하는 것보다는 프로젝트 진행에 더 중점을 두어 예외발생시 우선 log로만 남겨두도록 하고, 해당 문제는 후에 refactoring해야 하는 요소로 남겨두기로 결정함.

* 이벤트 publish를 200개 했을 경우 예외 발생
* ![image](https://user-images.githubusercontent.com/68679529/211756139-94633c34-9f79-431f-9876-12f969c4256e.png)
 